### PR TITLE
Download from HTTP://download.oracle.com

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@
     .stdout.trim() === 'No smoke!';
 
   const url = exports.url = () =>
-    'https://download.oracle.com/otn-pub/java/jdk/' +
+    'http://download.oracle.com/otn-pub/java/jdk/' +
     version + '-b' + build_number + '/' + hash + 
     '/jre-' + version + '-' + platform() + '-' + arch() + '.tar.gz';
 


### PR DESCRIPTION
Is there a particular reason for using `httpS`? Navigating to this url from chrome result in a `NET::ERR_CERT_COMMON_NAME_INVALID` and it might break builds.